### PR TITLE
Fix duplicated definitions of command-line parsers

### DIFF
--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -32,25 +32,5 @@ class ArfToHtml(Client):
 
     def prepare_parser(self):
         super().prepare_parser()
-        self.parser.add_argument(
-            '-i',
-            '--all-in-one',
-            action="store_true",
-            default=False,
-            help="Processes all rules into one file.")
-        self.parser.add_argument(
-            '-d',
-            '--display',
-            action="store_true",
-            default=False,
-            help="Enables opening a web browser with a graph, when is used --output.")
-        self.parser.add_argument(
-            '--show-failed-rules',
-            action="store_true",
-            default=False,
-            help="Show only FAILED rules")
-        self.parser.add_argument(
-            '--show-not-selected-rules',
-            action="store_true",
-            default=False,
-            help="Show notselected rules. These rules will not be visualized.")
+        self.prepare_args_when_output_is_html()
+        self.prepare_args_when_user_can_list_in_rules()

--- a/oval_graph/arf_to_html.py
+++ b/oval_graph/arf_to_html.py
@@ -15,7 +15,6 @@ class ArfToHtml(Client):
     def _get_message(self):
         MESSAGES = {
             'description': 'Client for visualization of SCAP rule evaluation results',
-            '--output': 'The directory where to save output directory with files.',
             'source_filename': 'ARF scan file',
         }
         return MESSAGES

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -60,13 +60,4 @@ class ArfToJson(Client):
 
     def prepare_parser(self):
         super().prepare_parser()
-        self.parser.add_argument(
-            '--show-failed-rules',
-            action="store_true",
-            default=False,
-            help="Show only FAILED rules")
-        self.parser.add_argument(
-            '--show-not-selected-rules',
-            action="store_true",
-            default=False,
-            help="Show notselected rules. These rules will not be visualized.")
+        self.prepare_args_when_user_can_list_in_rules()

--- a/oval_graph/arf_to_json.py
+++ b/oval_graph/arf_to_json.py
@@ -19,7 +19,6 @@ class ArfToJson(Client):
     def _get_message(self):
         MESSAGES = {
             'description': 'Client for generating JSON of SCAP rule evaluation results',
-            '--output': 'The file where to save output.',
             'source_filename': 'ARF scan file',
         }
         return MESSAGES

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -198,6 +198,32 @@ class Client():
         self.prepare_parser()
         return self.parser.parse_args(args)
 
+    def prepare_args_when_output_is_html(self):
+        self.parser.add_argument(
+            '-i',
+            '--all-in-one',
+            action="store_true",
+            default=False,
+            help="Processes all rules into one file.")
+        self.parser.add_argument(
+            '-d',
+            '--display',
+            action="store_true",
+            default=False,
+            help="Enables opening a web browser with a graph, when is used --output.")
+
+    def prepare_args_when_user_can_list_in_rules(self):
+        self.parser.add_argument(
+            '--show-failed-rules',
+            action="store_true",
+            default=False,
+            help="Show only FAILED rules")
+        self.parser.add_argument(
+            '--show-not-selected-rules',
+            action="store_true",
+            default=False,
+            help="Show notselected rules. These rules will not be visualized.")
+
     def prepare_parser(self):
         self.parser = argparse.ArgumentParser(
             prog='oval-graph',

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -39,7 +39,6 @@ class Client():
     def _get_message(self):
         MESSAGES = {
             'description': '',
-            '--output': '',
             'source_filename': '',
         }
         return MESSAGES
@@ -256,7 +255,7 @@ class Client():
             '--output',
             action="store",
             default=None,
-            help=self.MESSAGES.get('--output'))
+            help='The file where to save output.')
         self.parser.add_argument(
             "source_filename",
             help=self.MESSAGES.get('source_filename'))

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -87,15 +87,4 @@ class JsonToHtml(Client):
 
     def prepare_parser(self):
         super().prepare_parser()
-        self.parser.add_argument(
-            '-i',
-            '--all-in-one',
-            action="store_true",
-            default=False,
-            help="Processes all rules into one file.")
-        self.parser.add_argument(
-            '-d',
-            '--display',
-            action="store_true",
-            default=False,
-            help="Enables opening a web browser with a graph, when is used --output.")
+        self.prepare_args_when_output_is_html()

--- a/oval_graph/json_to_html.py
+++ b/oval_graph/json_to_html.py
@@ -38,7 +38,6 @@ class JsonToHtml(Client):
     def _get_message(self):
         MESSAGES = {
             'description': 'Client for visualization of JSON created by command arf-to-json',
-            '--output': 'The directory where to save output directory with files.',
             'source_filename': 'JSON file',
         }
         return MESSAGES


### PR DESCRIPTION
This PR fixes duplicated definitions of command-line parsers.
Fixes #145 