### PR TITLE
Moves the open web browser to the client

### DIFF
--- a/oval_graph/_builder_html_graph.py
+++ b/oval_graph/_builder_html_graph.py
@@ -1,5 +1,4 @@
 import os
-import webbrowser
 import json
 import re
 import sys
@@ -9,15 +8,13 @@ import lxml.html
 
 
 class BuilderHtmlGraph():
-    def __init__(self, parts, display_html, verbose):
+    def __init__(self, parts, verbose):
         self.parts = parts
-        self.display_html = display_html
         self.verbose = verbose
 
-    def save_html_and_open_html(self, dict_oval_trees, src, rules, out):
+    def save_html(self, dict_oval_trees, src, rules):
         self.save_html_report(dict_oval_trees, src)
-        self.print_output_message_and_open_web_browser(
-            src, self._format_rules_output(rules), out)
+        self.print_output_message(src, self._format_rules_output(rules))
 
     def save_html_report(self, dict_of_rules, src):
         with open(src, "w+") as data_file:
@@ -94,18 +91,9 @@ class BuilderHtmlGraph():
                 out += line
         return out
 
-    def print_output_message_and_open_web_browser(self, src, rule, out):
+    def print_output_message(self, src, rule):
         if self.verbose:
             print('Rule(s) "{}" done!'.format(rule), file=sys.stderr)
-        out.append(src)
-        self.open_web_browser(src)
-
-    def open_web_browser(self, src):
-        if self.display_html:
-            try:
-                webbrowser.get('firefox').open_new_tab(src)
-            except BaseException:
-                webbrowser.open_new_tab(src)
 
     def _format_rules_output(self, rules):
         out = ''

--- a/oval_graph/client.py
+++ b/oval_graph/client.py
@@ -165,12 +165,24 @@ class Client():
         _dir = os.path.dirname(os.path.realpath(__file__))
         return str(os.path.join(_dir, src))
 
-    def _build_and_save_html(self, dict_oval_trees, src, rules, out):
+    def _build_and_save_html(self, dict_oval_trees, src, rules, out_src):
         builder = BuilderHtmlGraph(
-            self.parts, self.display_html, self.verbose)
-        builder.save_html_and_open_html(dict_oval_trees, src, rules, out)
+            self.parts, self.verbose)
+        builder.save_html(dict_oval_trees, src, rules)
+        out_src.append(src)
 
-    def _prepare_data(self, rules, dict_oval_trees, out):
+    def open_html(self, out):
+        for src in out:
+            self.open_web_browser(src)
+
+    def open_web_browser(self, src):
+        if self.display_html:
+            try:
+                webbrowser.get('firefox').open_new_tab(src)
+            except BaseException:
+                webbrowser.open_new_tab(src)
+
+    def _prepare_data(self, rules, dict_oval_trees, out_src):
         for rule in rules['rules']:
             try:
                 self._put_to_dict_oval_trees(dict_oval_trees, rule)
@@ -178,20 +190,21 @@ class Client():
                     self._build_and_save_html(
                         dict_oval_trees, self._get_src_for_one_graph(
                             rule), dict(
-                            rules=[rule]), out)
+                            rules=[rule]), out_src)
                     dict_oval_trees = {}
             except NotChecked as error:
                 self.print_red_text(error)
         if self.all_in_one:
             self._build_and_save_html(
                 dict_oval_trees, self.get_save_src(
-                    'rules' + self.date), rules, out)
-        return out
+                    'rules' + self.date), rules, out_src)
 
     def prepare_data(self, rules):
-        out = []
+        out_src = []
         oval_tree_dict = dict()
-        return self._prepare_data(rules, oval_tree_dict, out)
+        self._prepare_data(rules, oval_tree_dict, out_src)
+        self.open_html(out_src)
+        return out_src
 
     def parse_arguments(self, args):
         self.prepare_parser()


### PR DESCRIPTION
This PR moves function for opening the web browser to the client because opening HTML will be used for future command `arf-to-report`.