### PR TITLE
Fixes links in  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oval-graph
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/?branch=master) [![Build Status](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/badges/build.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/build-status/master) [![Code Intelligence Status](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/badges/code-intelligence.svg?b=master)](https://scrutinizer-ci.com/code-intelligence)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/?branch=master) [![Build Status](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/badges/build.png?b=master)](https://scrutinizer-ci.com/g/OpenSCAP/OVAL-visualization-as-graph/build-status/master) [![Code Intelligence Status](https://scrutinizer-ci.com/g/OpenSCAP/oval-graph/badges/code-intelligence.svg?b=master)](https://scrutinizer-ci.com/code-intelligence)
 
 _Understanding result in the blink of an eye_
 
@@ -8,11 +8,11 @@ This tool generates an [OVAL](https://oval.cisecurity.org/) result in the form o
 
 ## Installation
 
-**[Learn how to install tool in the Guide.](docs/GUIDE.md#Installation)**
+**[Learn how to install tool in the Guide.](https://github.com/OpenSCAP/oval-graph/blob/master/docs/GUIDE.md#Installation)**
 
 ## Example usage
 
-> More usage examples are in user [Guide](./docs/GUIDE.md#Usage-Examples)
+> More usage examples are in user [Guide](https://github.com/OpenSCAP/oval-graph/blob/master/docs/GUIDE.md#Usage-Examples)
 
 This commands consumes the rule name or regular expression of rule name and the ARF file, which is one of possible standardized format for results of SCAP-compliant scanners. You can read about generating ARF report files using OpenSCAP in the OpenSCAP User [Manual](https://github.com/OpenSCAP/openscap/blob/maint-1.3/docs/manual/manual.adoc). Or you can use test arf files from repository `/tests/test_data`.  
 
@@ -22,4 +22,4 @@ arf-to-graph scan-data/ssg-fedora-ds-arf.xml xccdf_org.ssgproject.content_rule_a
 
 This command generates a graph and saves file named  `graph-of-<rule_id>-<date>.html` (The date the graph was created.) in the working directory. Then, it opens the generated file in your web browser. _Default web browser is Firefox. If Firefox is not installed, the default web browser in OS is used._
 
-![demo-screenshot](./docs/demo-screenshot.png "demo-screenshot")
+![demo-screenshot](https://raw.githubusercontent.com/OpenSCAP/oval-graph/master/docs/demo-screenshot.png "demo-screenshot")


### PR DESCRIPTION
This PR fixes README links and links on the PyPI page, but on [PyPI](https://pypi.org/project/oval-graph/) will not take effect until the next release (1.2.3).