### PR TITLE
PackIT config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,11 @@ actions:
   get-current-version:
     - "python3 setup.py --version"
 jobs:
+- job: sync_from_downstream
+  trigger: commit
+  metadata:
+    dist-git-branch: fedora-rawhide
+
 - job: propose_downstream
   trigger: release
   metadata:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,12 +16,12 @@ jobs:
 - job: sync_from_downstream
   trigger: commit
   metadata:
-    dist-git-branch: fedora-rawhide
+    dist_git_branches: fedora-rawhide
 
 - job: propose_downstream
   trigger: release
   metadata:
-    dist-git-branch: fedora-rawhide
+    dist_git_branches: fedora-rawhide
 
 - job: copr_build
   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,7 +4,7 @@ synced_files:
   - oval-graph.spec
 upstream_package_name: oval_graph
 downstream_package_name: oval-graph
-upstream_project_url: https://github.com/OpenSCAP/OVAL-visualization-as-graph
+upstream_project_url: https://github.com/OpenSCAP/oval-graph
 
 actions:
   create-archive:


### PR DESCRIPTION
This PR contains PackIt config improvements:

- Update URL upstream 
- Rename dist_git_branch to dist_git_branches, because it has been renamed in Packit. [Changelog](https://github.com/packit/packit/blob/main/CHANGELOG.md#0101)
- Add job for syncing spec file