### PR TITLE
Make sure that users can run tests from the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
 include README.md
 include LICENSE
+include tox.ini
+include test_suite_requirements.txt
+include test_commands.sh
 recursive-include oval_graph/parts *
 recursive-include oval_graph/schemas *
+recursive-include tests *.py
+recursive-include tests/test_data *


### PR DESCRIPTION
Test code, support scripts and data was not packaged along, so people who downloaded the pypi source package (that is also used as a Fedora source) can run the whole test suite without having to check out those files from Git.