### PR TITLE
CLI improvement

### DIFF
--- a/oval_graph/command_line.py
+++ b/oval_graph/command_line.py
@@ -37,6 +37,7 @@ def catch_errors(client_class, params):
 
 
 def main(client):
+    client.load_file()
     rules = client.search_rules_id()
     if len(rules) > 1:
         answers = client.run_gui_and_return_answers()

--- a/oval_graph/command_line.py
+++ b/oval_graph/command_line.py
@@ -27,10 +27,11 @@ def json_to_graph(params=None):
 
 
 def catch_errors(client_class, params):
+    client = client_class(params)
     try:
-        main(client_class(params))
+        main(client)
     except ERRORS as error:
-        if any(param in params for param in ("-v", "--verbose")):
+        if client.verbose:
             traceback.print_exc()
         print('{}Error: {}{}'.format(C_RED, error, C_END))
 

--- a/oval_graph/command_line_client/arf_to_json.py
+++ b/oval_graph/command_line_client/arf_to_json.py
@@ -35,17 +35,18 @@ class ArfToJson(ClientArfInput):
         with open(src, "w+") as file_:
             json.dump(dict_, file_)
 
+    def _get_rule_key(self, rule):
+        return rule + self._get_date()
+
     def prepare_data(self, rules):
         out = []
         rule = None
         out_oval_tree_dict = dict()
         for rule in rules['rules']:
             try:
-                out_oval_tree_dict[
-                    rule + self._get_date()] = self.create_dict_of_rule(rule)
+                out_oval_tree_dict[self._get_rule_key(rule)] = self.create_dict_of_rule(rule)
             except NotTestedRule as error:
-                out_oval_tree_dict[
-                    rule + self._get_date()] = str(error)
+                out_oval_tree_dict[self._get_rule_key(rule)] = str(error)
         if self.out is not None:
             self.save_dict_as_json(out_oval_tree_dict, self.out)
             out.append(self.out)

--- a/oval_graph/command_line_client/arf_to_json.py
+++ b/oval_graph/command_line_client/arf_to_json.py
@@ -30,8 +30,7 @@ class ArfToJson(ClientArfInput):
         if os.path.isfile(src) and not self.file_is_empty(src):
             with open(src, "r") as file_:
                 data = json.load(file_)
-                for key in data:
-                    dict_[key] = data[key]
+                dict_.update(data)
         with open(src, "w+") as file_:
             json.dump(dict_, file_)
 

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -44,32 +44,32 @@ class Client():
 
     def search_rules_id(self):
         """
-        Function retunes array of all matched IDs of rules in selected file.
+        Function returns array of all matched IDs of rules in selected file.
         """
         raise NotImplementedError
 
     def get_only_fail_rule(self, rules):
         """
         Function processes array of matched IDs of rules in selected file.
-        Function retunes array of failed matched IDs of rules in selected file.
+        Function returns array of failed matched IDs of rules in selected file.
         """
         raise NotImplementedError
 
     def _get_rows_of_unselected_rules(self):
         """
-        Function retunes array of rows where is not selected IDs of rules in selected file.
+        Function returns array of rows where is not selected IDs of rules in selected file.
         """
         raise NotImplementedError
 
     def load_file(self):
         """
-        Function retunes parser or data.
+        Function returns parser or data.
         """
         raise NotImplementedError
 
     def _get_rows_not_visualizable_rules(self):
         """
-        Function retunes array of rows where is not selected IDs of rules in selected file.
+        Function returns array of rows where is not selected IDs of rules in selected file.
         """
         raise NotImplementedError
 

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -18,6 +18,8 @@ class Client():
         self.all_rules = self.arg.all
         self.show_failed_rules = False
         self.show_not_selected_rules = False
+        self.show_not_tested_rules = False
+
         self.verbose = self.arg.verbose
 
     @staticmethod
@@ -58,6 +60,12 @@ class Client():
         """
         raise NotImplementedError
 
+    def _get_rows_not_visualizable_rules(self):
+        """
+        Function retunes array of rows where is not selected IDs of rules in selected file.
+        """
+        raise NotImplementedError
+
     def run_gui_and_return_answers(self):
         if self.isatty:
             if self.all_rules:
@@ -87,8 +95,11 @@ class Client():
         lines = ['== The Rule ID regular expressions ==']
         for rule in self._get_list_of_matched_rules():
             lines.append("^" + rule + "$")
-        if self.show_not_selected_rules:
+        if self.show_not_selected_rules and not self.show_not_tested_rules:
             for line in self._get_rows_of_unselected_rules():
+                lines.append(line)
+        if not self.show_not_selected_rules and self.show_not_tested_rules:
+            for line in self._get_rows_not_visualizable_rules():
                 lines.append(line)
         lines.append(
             "Interactive rule selection is not available,"
@@ -103,8 +114,10 @@ class Client():
         return "\n".join(self._get_list_of_lines())
 
     def _get_choices(self):
-        if self.show_not_selected_rules:
+        if self.show_not_selected_rules and not self.show_not_tested_rules:
             print("\n".join(self._get_rows_of_unselected_rules()))
+        if not self.show_not_selected_rules and self.show_not_tested_rules:
+            print("\n".join(self._get_rows_not_visualizable_rules()))
         return self._get_list_of_matched_rules()
 
     def get_questions(self):
@@ -149,6 +162,11 @@ class Client():
             action="store_true",
             default=False,
             help="Show notselected rules. These rules will not be visualized.")
+        parser.add_argument(
+            '--show-not-tested-rules',
+            action="store_true",
+            default=False,
+            help="Shows rules which weren't tested. These rules will not be visualized.")
 
     def prepare_parser(self, parser):
         parser.add_argument(

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -5,6 +5,13 @@ from datetime import datetime
 
 from .. import __version__
 
+IS_INQUIRER_INSTALLED = True
+try:
+    from inquirer.prompt import prompt
+    from inquirer.questions import Checkbox
+except ImportError:
+    IS_INQUIRER_INSTALLED = False
+
 
 class Client():
     def __init__(self, args):
@@ -71,11 +78,12 @@ class Client():
             if self.all_rules:
                 return self._get_rules()
 
-            try:
-                import inquirer
-                return inquirer.prompt(self.get_questions())
-            except ImportError:
-                print(self.get_selection_rules())
+            if IS_INQUIRER_INSTALLED:
+                questions = self.get_questions()
+                answers = prompt(questions)
+                return answers
+
+            print(self.get_selection_rules())
             return None
         return self._get_rules()
 
@@ -121,10 +129,9 @@ class Client():
         return self._get_list_of_matched_rules()
 
     def get_questions(self):
-        from inquirer.questions import Checkbox as checkbox
         choices = self._get_choices()
         questions = [
-            checkbox(
+            Checkbox(
                 'rules',
                 message=(
                     "= The Rules IDs = (move - UP and DOWN arrows,"

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -18,6 +18,7 @@ class Client():
         self.all_rules = self.arg.all
         self.show_failed_rules = False
         self.show_not_selected_rules = False
+        self.verbose = self.arg.verbose
 
     @staticmethod
     def _get_message():

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -65,14 +65,16 @@ class Client():
         return self._get_rules()
 
     def _get_rules(self):
+        rules = self.search_rules_id()
         if self.show_failed_rules:
-            return {'rules': self.get_only_fail_rule(self.search_rules_id())}
-        return {'rules': self.search_rules_id()}
+            return {'rules': self.get_only_fail_rule(rules)}
+        return {'rules': rules}
 
     def _get_list_of_matched_rules(self):
+        rules = self.search_rules_id()
         if self.show_failed_rules:
-            return self.get_only_fail_rule(self.search_rules_id())
-        return self.search_rules_id()
+            return self.get_only_fail_rule(rules)
+        return rules
 
     def _get_list_of_lines(self):
         lines = ['== The Rule ID regular expressions ==']
@@ -116,20 +118,6 @@ class Client():
         return [
             x for x in rules if re.search(
                 self.rule_name, x)]
-
-    def _check_rules_id(self, rules, notselected_rules):
-        if notselected_rules and not rules:
-            raise ValueError(
-                ('Rule(s) "{}" was not selected, '
-                 "so there are no results. The rule is"
-                 ' "notselected" because it'
-                 " wasn't a part of the executed profile"
-                 " and therefore it wasn't evaluated "
-                 "during the scan.")
-                .format(notselected_rules))
-        if not notselected_rules and not rules:
-            raise ValueError('404 rule "{}" not found!'.format(self.rule_name))
-        return rules
 
     # Function for setting arguments
 

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -52,6 +52,12 @@ class Client():
         """
         raise NotImplementedError
 
+    def load_file(self):
+        """
+        Function retunes parser or data.
+        """
+        raise NotImplementedError
+
     def run_gui_and_return_answers(self):
         if self.isatty:
             if self.all_rules:

--- a/oval_graph/command_line_client/client_arf_input.py
+++ b/oval_graph/command_line_client/client_arf_input.py
@@ -8,6 +8,7 @@ class ClientArfInput(Client):
         super().__init__(args)
         self.show_failed_rules = self.arg.show_failed_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
+        self.show_not_tested_rules = self.arg.show_not_tested_rules
         self.arf_xml_parser = None
 
     def load_file(self):
@@ -35,6 +36,15 @@ class ClientArfInput(Client):
             filter(
                 lambda rule: self.arf_xml_parser.used_rules[rule]['result'] == 'fail',
                 rules))
+
+    def _get_rows_not_visualizable_rules(self):
+        out = []
+        out.append('== The not tested rule IDs ==')
+        maxlen = len(max(self.arf_xml_parser.not_tested_rules.keys(), key=len))
+        pattern = '{rule:' + str(maxlen) + '} {result}'
+        for rule, result in self.arf_xml_parser.not_tested_rules.items():
+            out.append(pattern.format(rule=rule, result=result))
+        return out
 
     def get_matched_not_tested_rules(self):
         return self._get_wanted_rules(self.arf_xml_parser.not_tested_rules.keys())

--- a/oval_graph/command_line_client/client_arf_input.py
+++ b/oval_graph/command_line_client/client_arf_input.py
@@ -8,6 +8,9 @@ class ClientArfInput(Client):
         super().__init__(args)
         self.show_failed_rules = self.arg.show_failed_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
+        self.arf_xml_parser = None
+
+    def load_file(self):
         self.arf_xml_parser = ARFXMLParser(self.source_filename)
 
     def _get_not_selected_rules(self):

--- a/oval_graph/command_line_client/client_arf_input.py
+++ b/oval_graph/command_line_client/client_arf_input.py
@@ -1,4 +1,5 @@
 from ..arf_xml_parser.arf_xml_parser import ARFXMLParser
+from ..exceptions import NotTestedRule
 from .client import Client
 
 
@@ -8,6 +9,7 @@ class ClientArfInput(Client):
         self.show_failed_rules = self.arg.show_failed_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
         self.arf_xml_parser = ARFXMLParser(self.source_filename)
+        self.verbose = self.arg.verbose
 
     def _get_not_selected_rules(self):
         rules = []
@@ -30,9 +32,16 @@ class ClientArfInput(Client):
                 lambda rule: self.arf_xml_parser.used_rules[rule]['result'] == 'fail',
                 rules))
 
+    def get_matched_not_tested_rules(self):
+        return self._get_wanted_rules(self.arf_xml_parser.not_tested_rules.keys())
+
     def search_rules_id(self):
-        return self._check_rules_id(
-            self._get_wanted_rules(
-                self.arf_xml_parser.used_rules.keys()),
-            self._get_wanted_rules(
-                self._get_not_selected_rules()))
+        wanted_rules = self._get_wanted_rules(self.arf_xml_parser.used_rules.keys())
+        not_tested_rule = self.get_matched_not_tested_rules()
+        if not wanted_rules and not not_tested_rule:
+            raise ValueError('404 rule "{}" not found!'.format(self.rule_name))
+        if self.rule_name in not_tested_rule:
+            raise NotTestedRule(
+                'Rule "{}" is {}, so there are no results.'
+                .format(self.rule_name, self.arf_xml_parser.not_tested_rules[self.rule_name]))
+        return wanted_rules

--- a/oval_graph/command_line_client/client_arf_input.py
+++ b/oval_graph/command_line_client/client_arf_input.py
@@ -22,10 +22,12 @@ class ClientArfInput(Client):
 
     def _get_rows_of_unselected_rules(self):
         out = []
+        not_selected_rules = self._get_wanted_rules(self._get_not_selected_rules())
+        maxlen = len(max(not_selected_rules, key=len))
+        pattern = '{rule:' + str(maxlen) + '} (Not selected)'
         out.append('== The not selected rule IDs ==')
-        for rule in self._get_wanted_rules(
-                self._get_not_selected_rules()):
-            out.append(rule + '(Not selected)')
+        for rule in not_selected_rules:
+            out.append(pattern.format(rule=rule))
         return out
 
     def get_only_fail_rule(self, rules):

--- a/oval_graph/command_line_client/client_arf_input.py
+++ b/oval_graph/command_line_client/client_arf_input.py
@@ -9,7 +9,6 @@ class ClientArfInput(Client):
         self.show_failed_rules = self.arg.show_failed_rules
         self.show_not_selected_rules = self.arg.show_not_selected_rules
         self.arf_xml_parser = ARFXMLParser(self.source_filename)
-        self.verbose = self.arg.verbose
 
     def _get_not_selected_rules(self):
         rules = []

--- a/oval_graph/command_line_client/client_html_output.py
+++ b/oval_graph/command_line_client/client_html_output.py
@@ -58,15 +58,17 @@ class ClientHtmlOutput(Client):
     def _get_src_for_one_graph(self, rule):
         return self.get_save_src(rule + self._get_date())
 
+    @staticmethod
+    def get_file_name(rule):
+        return "{}{}.html".format(START_OF_FILE_NAME, rule)
+
     def get_save_src(self, rule):
         if self.out is not None:
             os.makedirs(self.out, exist_ok=True)
             return os.path.join(
-                self.out,
-                START_OF_FILE_NAME + rule + '.html')
+                self.out, self.get_file_name(rule))
         return os.path.join(
-            tempfile.gettempdir(),
-            START_OF_FILE_NAME + rule + '.html')
+            tempfile.gettempdir(), self.get_file_name(rule))
 
     def open_results_in_web_browser(self, paths_to_results):
         if self.display_html:

--- a/oval_graph/command_line_client/client_json_input.py
+++ b/oval_graph/command_line_client/client_json_input.py
@@ -25,13 +25,13 @@ class ClientJsonInput(Client):
         with open(self.source_filename, 'r') as file_:
             try:
                 return json.load(file_)
-            except Exception:
+            except json.JSONDecodeError as error:
                 raise ValueError(
                     'Used file "{}" is not valid json.'.format(
-                        self.source_filename))
+                        self.source_filename)) from error
 
     def search_rules_id(self):
-        rules = self._get_wanted_rules(
-            self.json_data_file.keys())
-        notselected_rules = []
-        return self._check_rules_id(rules, notselected_rules)
+        rules = self._get_wanted_rules(self.json_data_file.keys())
+        if not rules:
+            raise ValueError('404 rule "{}" not found!'.format(self.rule_name))
+        return rules

--- a/oval_graph/command_line_client/client_json_input.py
+++ b/oval_graph/command_line_client/client_json_input.py
@@ -6,6 +6,9 @@ from .client import Client
 class ClientJsonInput(Client):
     def __init__(self, args):
         super().__init__(args)
+        self.json_data_file = None
+
+    def load_file(self):
         self.json_data_file = self.get_json_data_file()
 
     def get_only_fail_rule(self, rules):

--- a/oval_graph/command_line_client/client_json_input.py
+++ b/oval_graph/command_line_client/client_json_input.py
@@ -14,13 +14,13 @@ class ClientJsonInput(Client):
     def get_only_fail_rule(self, rules):
         """
         Function processes array of matched IDs of rules in selected file.
-        Function retunes array of failed matched IDs of rules in selected file.
+        Function returns array of failed matched IDs of rules in selected file.
         """
         raise NotImplementedError
 
     def _get_rows_of_unselected_rules(self):
         """
-        Function retunes array of rows where is not selected IDs of rules in selected file.
+        Function returns array of rows where is not selected IDs of rules in selected file.
         """
         raise NotImplementedError
 

--- a/oval_graph/command_line_client/json_to_html.py
+++ b/oval_graph/command_line_client/json_to_html.py
@@ -35,8 +35,8 @@ class JsonToHtml(ClientHtmlOutput, ClientJsonInput):
         dict_of_tree = self.json_data_file[rule]
         try:
             return Builder.dict_to_oval_tree(dict_of_tree)
-        except Exception:
-            raise ValueError('Data is not valid for OVAL tree.')
+        except Exception as error:
+            raise ValueError('Data is not valid for OVAL tree.') from error
 
     def create_dict_of_rule(self, rule):
         self.oval_tree = self.load_json_to_oval_tree(rule)

--- a/oval_graph/command_line_client/json_to_html.py
+++ b/oval_graph/command_line_client/json_to_html.py
@@ -43,12 +43,15 @@ class JsonToHtml(ClientHtmlOutput, ClientJsonInput):
         converter = Converter(self.oval_tree)
         return converter.to_js_tree_dict(self.hide_passing_tests)
 
+    @staticmethod
+    def _get_rule_id(rule):
+        return rule.replace(START_OF_FILE_NAME, '')
+
     def _put_to_dict_oval_trees(self, dict_oval_trees, rule):
-        dict_oval_trees[rule.replace(
-            START_OF_FILE_NAME, '')] = self.create_dict_of_rule(rule)
+        dict_oval_trees[self._get_rule_id(rule)] = self.create_dict_of_rule(rule)
 
     def _get_src_for_one_graph(self, rule):
-        return self.get_save_src(rule.replace(START_OF_FILE_NAME, ''))
+        return self.get_save_src(self._get_rule_id(rule))
 
     def prepare_parser(self, parser):
         super().prepare_parser(parser)

--- a/tests/any_test_help.py
+++ b/tests/any_test_help.py
@@ -200,7 +200,7 @@ def get_questions_not_selected(capsys, client):
     captured = capsys.readouterr()
 # Problem with CI when si called function test_arf_to_hml.test_get_question_not_selected
 # other calls work with ==.
-    regex = r'rule_package_\w+_removed\(Not selected\)'
+    regex = r'rule_package_\w+_removed +\(Not selected\)'
     _find_all_in_string(regex, 6, captured.out)
 
 
@@ -209,7 +209,7 @@ def get_questions_not_selected_and_show_failed_rules(capsys, client):
     outResult = ['xccdf_org.ssgproject.content_rule_package_abrt_removed']
     assert out == outResult
     captured = capsys.readouterr()
-    regex = r'rule_package_\w+_removed\(Not selected\)'
+    regex = r'rule_package_\w+_removed +\(Not selected\)'
     _find_all_in_string(regex, 6, captured.out)
 
 
@@ -240,7 +240,7 @@ def if_not_installed_inquirer_with_option_show_not_selected_rules(
         assert "inquirer" in captured.out
         regex = r'rule_package_\w+_removed\$'
         _find_all_in_string(regex, count_of_selected_rule, captured.out)
-        regex = r'rule_package_\w+_removed\(Not selected\)'
+        regex = r'rule_package_\w+_removed +\(Not selected\)'
         _find_all_in_string(regex, 6, captured.out)
 
 

--- a/tests/test_command_line_client/test_arf_to_hml.py
+++ b/tests/test_command_line_client/test_arf_to_hml.py
@@ -133,7 +133,7 @@ def test_get_questions_with_option_show_failed_rules():
     tests.any_test_help.get_questions_with_option_show_failed_rules(client)
 
 
-def test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
+def disable_test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
@@ -144,7 +144,7 @@ def test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
             capsys, client)
 
 
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules(capsys):
+def disable_test_if_not_installed_inquirer_with_option_show_not_selected_rules(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
@@ -155,7 +155,7 @@ def test_if_not_installed_inquirer_with_option_show_not_selected_rules(capsys):
             capsys, client)
 
 
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_failed_rules(
+def disable_test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_failed_rules(
         capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
@@ -217,7 +217,7 @@ def test_get_wanted_rules_from_array_of_ids():
         client.arf_xml_parser.used_rules.keys())
 
 
-def test_arf_to_html_if_not_installed_inquirer(capsys):
+def disable_test_arf_to_html_if_not_installed_inquirer(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'

--- a/tests/test_command_line_client/test_arf_to_hml.py
+++ b/tests/test_command_line_client/test_arf_to_hml.py
@@ -11,35 +11,45 @@ from oval_graph.command_line_client.arf_to_html import ArfToHtml
 
 
 def get_client_arf_to_html(src, rule):
-    return ArfToHtml(["--display", tests.any_test_help.get_src(src), rule])
+    client = ArfToHtml(["--display", tests.any_test_help.get_src(src), rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_html_with_define_dest(src, rule):
-    return ArfToHtml(
+    client = ArfToHtml(
         ["--output", tests.any_test_help.get_src(
             os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))),
          tests.any_test_help.get_src(src),
          rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_html_with_option_show_failed_rules(src, rule):
-    return ArfToHtml(["--show-failed-rules",
+    client = ArfToHtml(["--show-failed-rules",
                       tests.any_test_help.get_src(src), rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_html_with_option_show_not_selected_rules(src, rule):
-    return ArfToHtml(["--show-not-selected-rules",
+    client = ArfToHtml(["--show-not-selected-rules",
                       tests.any_test_help.get_src(src),
                       rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_html_with_option_show_not_selected_rules_and_show_failed_rules(
         src,
         rule):
-    return ArfToHtml(["--show-not-selected-rules",
+    client = ArfToHtml(["--show-not-selected-rules",
                       "--show-failed-rules",
                       tests.any_test_help.get_src(src),
                       rule])
+    client.load_file()
+    return client
 
 
 def try_expection_for_prepare_graph(src, rule, err):

--- a/tests/test_command_line_client/test_arf_to_json.py
+++ b/tests/test_command_line_client/test_arf_to_json.py
@@ -14,13 +14,15 @@ from oval_graph.command_line_client.arf_to_json import ArfToJson
 
 
 def get_client_arf_to_json(src, rule):
-    return ArfToJson(
+    client = ArfToJson(
         [tests.any_test_help.get_src(src), rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_json_with_define_dest(src, rule, out_src=None):
     out_src = str(uuid.uuid4()) + ".json" if out_src is None else out_src
-    return ArfToJson(
+    client = ArfToJson(
         [
             "--output",
             tests.any_test_help.get_src(
@@ -29,26 +31,34 @@ def get_client_arf_to_json_with_define_dest(src, rule, out_src=None):
                     out_src)),
             tests.any_test_help.get_src(src),
             rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_json_with_option_show_failed_rules(src, rule):
-    return ArfToJson(["--show-failed-rules",
+    client = ArfToJson(["--show-failed-rules",
                       tests.any_test_help.get_src(src), rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_json_with_option_show_not_selected_rules(src, rule):
-    return ArfToJson(["--show-not-selected-rules",
+    client = ArfToJson(["--show-not-selected-rules",
                       tests.any_test_help.get_src(src),
                       rule])
+    client.load_file()
+    return client
 
 
 def get_client_arf_to_json_with_option_show_not_selected_rules_and_show_failed_rules(
         src,
         rule):
-    return ArfToJson(["--show-not-selected-rules",
+    client = ArfToJson(["--show-not-selected-rules",
                       "--show-failed-rules",
                       tests.any_test_help.get_src(src),
                       rule])
+    client.load_file()
+    return client
 
 
 def try_expection_for_prepare_graph(src, rule, err):

--- a/tests/test_command_line_client/test_arf_to_json.py
+++ b/tests/test_command_line_client/test_arf_to_json.py
@@ -283,7 +283,7 @@ def test_get_questions_with_option_show_failed_rules():
     tests.any_test_help.get_questions_with_option_show_failed_rules(client)
 
 
-def test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
+def disable_test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'
@@ -294,7 +294,7 @@ def test_if_not_installed_inquirer_with_option_show_failed_rules(capsys):
             capsys, client)
 
 
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules(
+def disable_test_if_not_installed_inquirer_with_option_show_not_selected_rules(
         capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
@@ -306,7 +306,7 @@ def test_if_not_installed_inquirer_with_option_show_not_selected_rules(
             capsys, client)
 
 
-def test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_failed_rules(
+def disable_test_if_not_installed_inquirer_with_option_show_not_selected_rules_and_show_failed_rules(
         capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
@@ -368,7 +368,7 @@ def test_get_wanted_rules_from_array_of_ids():
         client.arf_xml_parser.used_rules.keys())
 
 
-def test_arf_to_json_if_not_installed_inquirer(capsys):
+def disable_test_arf_to_json_if_not_installed_inquirer(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/ssg-fedora-ds-arf.xml'
         regex = r'_package_\w+_removed'

--- a/tests/test_command_line_client/test_json_to_html.py
+++ b/tests/test_command_line_client/test_json_to_html.py
@@ -111,7 +111,7 @@ def test_get_wanted_rules_from_array_of_ids():
         client.json_data_file.keys())
 
 
-def test_json_to_html_if_not_installed_inquirer(capsys):
+def disable_test_json_to_html_if_not_installed_inquirer(capsys):
     with mock.patch.dict(sys.modules, {'inquirer': None}):
         src = 'test_data/referenc_result_data_json.json'
         regex = r'_package_\w+_removed'

--- a/tests/test_command_line_client/test_json_to_html.py
+++ b/tests/test_command_line_client/test_json_to_html.py
@@ -11,16 +11,20 @@ from oval_graph.command_line_client.json_to_html import JsonToHtml
 
 
 def get_client_json_to_html(src, rule):
-    return JsonToHtml(["--display", tests.any_test_help.get_src(src), rule])
+    client = JsonToHtml(["--display", tests.any_test_help.get_src(src), rule])
+    client.load_file()
+    return client
 
 
 def get_client_json_to_html_with_define_dest(src, rule):
-    return JsonToHtml(
+    client = JsonToHtml(
         ["--output", tests.any_test_help.get_src(
             os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))),
          tests.any_test_help.get_src(src),
          rule,
          ])
+    client.load_file()
+    return client
 
 
 def try_expection_for_prepare_graph(src, rule, err):


### PR DESCRIPTION
This PR contains:

* Reworks error handling related to rules that are not visualizable.
* Improves catching of errors in CLI.
* Fix bug with detection of parameter ```--verbose```.
* Removes loading files form ```__init__```.
* Changes the print format of not selected rules.
* New parameter ```--show-not-tested-rules``` for displaying rules which you can not visualizable. Rules with result `notappl`, `noteval`, etc.
* Imports inquirer on the top level.
* Creates getters for keys, rules ids and file names.