### PR TITLE
Fix problem with saving the report to dir or to file when is used `--output`

### DIFF
--- a/oval_graph/command_line.py
+++ b/oval_graph/command_line.py
@@ -11,7 +11,7 @@ from .exceptions import NotTestedRule
 
 C_RED = '\033[91m'
 C_END = '\033[0m'
-ERRORS = (ValueError, TypeError, ResourceWarning, NotTestedRule)
+ERRORS = (ValueError, TypeError, ResourceWarning, NotTestedRule, OSError)
 
 
 def arf_to_graph(params=None):

--- a/oval_graph/command_line_client/client.py
+++ b/oval_graph/command_line_client/client.py
@@ -204,7 +204,8 @@ class Client():
             '--output',
             action="store",
             default=None,
-            help='The file where to save output.')
+            help=("The path where to save the output. If there are more report "
+                  "files to generate it will create an OUTPUT path as a directory."))
         parser.add_argument(
             "source_filename",
             help=self._get_message().get('source_filename'))

--- a/oval_graph/html_builder/graph.py
+++ b/oval_graph/html_builder/graph.py
@@ -19,11 +19,12 @@ class Graph():
         self.script = self._get_part('script.js')
         self.search_bar = self._get_search_bar()
 
-    def save_html(self, dict_oval_trees, src):
-        with open(src, "wb+") as data_file:
+    def save_html(self, dict_oval_trees, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb+") as data_file:
             data_file.writelines(self._get_html(dict_oval_trees))
         if self.verbose:
-            self.print_output_message(src, list(dict_oval_trees.keys()))
+            self.print_output_message(path, list(dict_oval_trees.keys()))
 
     def _get_html(self, dict_of_rules):
         html = E.html(

--- a/tests_oval_graph/test_commands/command_constants.py
+++ b/tests_oval_graph/test_commands/command_constants.py
@@ -1,11 +1,11 @@
-TEST_ARF_XML_PATCH = 'tests_oval_graph/global_test_data/ssg-fedora-ds-arf.xml'
+TEST_ARF_XML_PATH = 'tests_oval_graph/global_test_data/ssg-fedora-ds-arf.xml'
 
 COMMAND_START = ['python3',
                  '-m',
                  'oval_graph.command_line',
                  ]
 
-COMMAND_END = [TEST_ARF_XML_PATCH,
+COMMAND_END = [TEST_ARF_XML_PATH,
                'xccdf_org.ssgproject.content_rule_package_abrt_removed',
                ]
 
@@ -22,7 +22,7 @@ ARF_TO_JSON = [*COMMAND_START,
 
 BAD_JSON_TO_GRAPH = [*COMMAND_START,
                      'json-to-graph',
-                     TEST_ARF_XML_PATCH,
+                     TEST_ARF_XML_PATH,
                      '.'
                      ]
 

--- a/tests_oval_graph/test_commands/test_command_arf_to_graph.py
+++ b/tests_oval_graph/test_commands/test_command_arf_to_graph.py
@@ -1,4 +1,3 @@
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -8,14 +7,14 @@ import pytest
 from readchar import key
 
 from ..test_tools import TestTools
-from .command_constants import ARF_TO_GRAPH, COMMAND_START, TEST_ARF_XML_PATCH
+from .command_constants import ARF_TO_GRAPH, COMMAND_START, TEST_ARF_XML_PATH
 
 
-def get_command_with_random_output_patch():
-    src = TestTools.get_random_dir_in_tmp()
+def get_command_with_random_output_path():
+    path = TestTools.get_random_path_in_tmp()
     command = [*ARF_TO_GRAPH]
-    command[command.index('.')] = src
-    return command, src
+    command[command.index('.')] = str(path)
+    return command, str(path)
 
 
 @pytest.mark.usefixtures("remove_generated_reports_in_root")
@@ -42,18 +41,18 @@ def test_command_arf_to_graph_with_verbose():
 
 
 def test_command_arf_to_graph_with_out_parameter():
-    command, src = get_command_with_random_output_patch()
+    command, src = get_command_with_random_output_path()
     subprocess.check_call(command)
     TestTools.compare_results_html(src)
 
 
 def test_inquirer_choice_rule():
-    src = TestTools.get_random_dir_in_tmp()
+    path = TestTools.get_random_path_in_tmp()
     command_parameters = [*COMMAND_START,
                           'arf-to-graph',
                           '-o',
-                          src,
-                          TEST_ARF_XML_PATCH,
+                          str(path),
+                          TEST_ARF_XML_PATH,
                           r'_package_\w+_removed'
                           ]
     command_parameters.remove("python3")
@@ -63,33 +62,33 @@ def test_inquirer_choice_rule():
     sut.send(key.SPACE)
     sut.send(key.ENTER)
     sut.wait()
-    assert os.path.isfile(src)
+    assert path.is_file()
 
 
 def test_command_parameter_all():
-    src = TestTools.get_random_dir_in_tmp()
+    path = TestTools.get_random_path_in_tmp()
     command = [*COMMAND_START,
                'arf-to-graph',
                '--all',
                '-o',
-               src,
-               TEST_ARF_XML_PATCH,
+               str(path),
+               TEST_ARF_XML_PATH,
                '.',
                ]
     subprocess.check_call(command)
-    assert len(os.listdir(src)) == 184
+    assert len(list(path.glob("**/*.html"))) == 184
 
 
 def test_command_parameter_all_and_show_failed_rules():
-    src = TestTools.get_random_dir_in_tmp()
+    path = TestTools.get_random_path_in_tmp()
     command = [*COMMAND_START,
                'arf-to-graph',
                '--all',
                '--show-failed-rules',
                '-o',
-               src,
-               TEST_ARF_XML_PATCH,
+               str(path),
+               TEST_ARF_XML_PATH,
                r'_package_\w+_removed'
                ]
     subprocess.check_call(command)
-    assert os.path.isfile(src)
+    assert path.is_file()

--- a/tests_oval_graph/test_commands/test_command_arf_to_graph.py
+++ b/tests_oval_graph/test_commands/test_command_arf_to_graph.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+from pathlib import Path
 
 import pexpect
 import pytest
@@ -34,17 +35,16 @@ def test_command_arf_to_graph_with_verbose():
                                   cwd='./',
                                   stderr=subprocess.STDOUT)
     # Reads path to file from verbose output
-    src_regex = r"\"(\.\/.*?)\""
+    src_regex = r"\"(.*?)\"$"
     src = re.search(src_regex, out.decode('utf-8')).group(1)
-    file_src = '.{}'.format(src)
+    file_src = Path(__file__).parent.parent.parent / src
     TestTools.compare_results_html(file_src)
 
 
 def test_command_arf_to_graph_with_out_parameter():
     command, src = get_command_with_random_output_patch()
     subprocess.check_call(command)
-    file_src = os.path.join(src, os.listdir(src)[0])
-    TestTools.compare_results_html(file_src)
+    TestTools.compare_results_html(src)
 
 
 def test_inquirer_choice_rule():
@@ -63,9 +63,7 @@ def test_inquirer_choice_rule():
     sut.send(key.SPACE)
     sut.send(key.ENTER)
     sut.wait()
-    assert len(os.listdir(src)) == 1
-    assert ("xccdf_org.ssgproject.content_rule_package_sendmail_removed"
-            in os.listdir(src)[0])
+    assert os.path.isfile(src)
 
 
 def test_command_parameter_all():
@@ -94,4 +92,4 @@ def test_command_parameter_all_and_show_failed_rules():
                r'_package_\w+_removed'
                ]
     subprocess.check_call(command)
-    assert len(os.listdir(src)) == 1
+    assert os.path.isfile(src)

--- a/tests_oval_graph/test_commands/test_command_arf_to_json.py
+++ b/tests_oval_graph/test_commands/test_command_arf_to_json.py
@@ -6,22 +6,22 @@ import pexpect
 from readchar import key
 
 from ..test_tools import TestTools
-from .command_constants import ARF_TO_JSON, COMMAND_START, TEST_ARF_XML_PATCH
+from .command_constants import ARF_TO_JSON, COMMAND_START, TEST_ARF_XML_PATH
 
 
 def run_commad_and_save_output_to_file(parameters):
-    src = TestTools.get_random_dir_in_tmp() + '.json'
-    with open(src, 'w+') as output:
+    path = str(TestTools.get_random_path_in_tmp()) + '.json'
+    with open(path, 'w+') as output:
         subprocess.check_call(parameters, stdout=output)
-    return src
+    return path
 
 
 def test_command_arf_to_json():
-    src = TestTools.get_random_dir_in_tmp() + '.json'
+    path = str(TestTools.get_random_path_in_tmp()) + '.json'
     out = subprocess.check_output(ARF_TO_JSON)
-    with open(src, "w+") as data:
+    with open(path, "w+") as data:
         data.writelines(out.decode('utf-8'))
-    TestTools.compare_results_json(src)
+    TestTools.compare_results_json(path)
 
 
 def test_command_arf_to_json_is_tty():
@@ -30,7 +30,7 @@ def test_command_arf_to_json_is_tty():
 
 
 def test_inquirer_choice_rule():
-    src = TestTools.get_random_dir_in_tmp() + '.json'
+    path = str(TestTools.get_random_path_in_tmp()) + '.json'
 
     command_parameters = [*ARF_TO_JSON]
     command_parameters.remove("python3")
@@ -44,16 +44,16 @@ def test_inquirer_choice_rule():
         sut.send(key_)
     sut.wait()
     out = sut.readlines()
-    with open(src, "w+") as data:
+    with open(path, "w+") as data:
         data.writelines(row.decode("utf-8") for row in out[24:])
-    TestTools.compare_results_json(src)
+    TestTools.compare_results_json(path)
 
 
 def test_command_parameter_all():
     command = [*COMMAND_START,
                "arf-to-json",
                "--all",
-               TEST_ARF_XML_PATCH,
+               TEST_ARF_XML_PATH,
                ".",
                ]
     src = run_commad_and_save_output_to_file(command)
@@ -67,7 +67,7 @@ def test_command_parameter_all_and_show_failed_rules():
                'arf-to-json',
                '--all',
                '--show-failed-rules',
-               TEST_ARF_XML_PATCH,
+               TEST_ARF_XML_PATH,
                r'_package_\w+_removed'
                ]
     src = run_commad_and_save_output_to_file(command)
@@ -80,7 +80,7 @@ def test_command_with_parameter_out():
     command = [*COMMAND_START,
                'arf-to-json',
                '--all',
-               TEST_ARF_XML_PATCH,
+               TEST_ARF_XML_PATH,
                r'_package_\w+_removed'
                ]
     src = run_commad_and_save_output_to_file(command)

--- a/tests_oval_graph/test_commands/test_command_json_to_graph.py
+++ b/tests_oval_graph/test_commands/test_command_json_to_graph.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+from pathlib import Path
 
 import pexpect
 import pytest
@@ -49,9 +50,9 @@ def test_command_json_to_graph_with_verbose():
     out = subprocess.check_output(command,
                                   cwd='./',
                                   stderr=subprocess.STDOUT)
-    src_regex = r"\"(\.\/.*?)\""
+    src_regex = r"\"(.*?)\"$"
     src = re.search(src_regex, out.decode('utf-8')).group(1)
-    file_src = '.{}'.format(src)
+    file_src = Path(__file__).parent.parent.parent / src
     TestTools.compare_results_html(file_src)
 
 
@@ -70,8 +71,7 @@ def test_command_json_to_graph_is_tty():
               ]
     subprocess.check_output(commad)
 
-    file_src = os.path.join(out_dir, os.listdir(out_dir)[0])
-    TestTools.compare_results_html(file_src)
+    TestTools.compare_results_html(out_dir)
 
 
 def test_inquirer_choice_rule():
@@ -111,9 +111,7 @@ def test_inquirer_choice_rule():
     for key_ in keys:
         sut.send(key_)
     sut.wait()
-    assert len(os.listdir(out_dir)) == 1
-    assert ("xccdf_org.ssgproject.content_rule_package_abrt_removed"
-            in os.listdir(out_dir)[0])
+    assert os.path.isfile(out_dir)
 
 
 def test_command_parameter_all():

--- a/tests_oval_graph/test_tools.py
+++ b/tests_oval_graph/test_tools.py
@@ -28,8 +28,8 @@ class TestTools():
             return data.readlines()
 
     @staticmethod
-    def get_random_dir_in_tmp():
-        return os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
+    def get_random_path_in_tmp():
+        return Path(tempfile.gettempdir()) / str(uuid.uuid4())
 
     @staticmethod
     def compare_results_html(result):


### PR DESCRIPTION
This PR fixes problem with saving the report to dir or to file when is used `--output`. When the user wants to generate more reports it will create OUTPUT as a directory.